### PR TITLE
Windows Support

### DIFF
--- a/src/svgstore.ts
+++ b/src/svgstore.ts
@@ -149,7 +149,7 @@ class WebpackSvgStore implements IWebpackSvgStore {
   }
 
   createTaskContext() {
-    const files = globby.sync(this.options.path);
+    const files = globby.sync(this.options.path.replace(/\\/g, "/"));
     const fileContent = this.parseFiles(files, this.options);
 
     this.addTask(this.options.path, {


### PR DESCRIPTION
Globby Pattern syntax.
Always use forward-slashes in glob expressions Use backslashes for escaping characters.
https://github.com/mrmlnc/fast-glob?tab=readme-ov-file#pattern-syntax